### PR TITLE
Added ingestion of Canada transit network

### DIFF
--- a/src/responses.rs
+++ b/src/responses.rs
@@ -268,8 +268,17 @@ pub struct Train {
     pub last_value: DateTime<FixedOffset>,
 
     /// Unsure of what this field symbolizes.
+    ///
+    /// Note: Only provided if provider is "Amtrak"
     #[serde(rename = "objectID")]
-    pub object_id: u32,
+    pub object_id: Option<u32>,
+
+    /// The provider network of this information
+    ///
+    /// # Examples:
+    /// * `Amtrak`
+    /// * `Via`
+    pub provider: String,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/tests/train.rs
+++ b/tests/train.rs
@@ -256,7 +256,8 @@ async fn test_single_train() -> Result<(), amtrak_api::Error> {
             "createdAt": "2023-08-29T23:39:50-04:00",
             "updatedAt": "2023-08-29T23:39:50-04:00",
             "lastValTS": "2023-08-29T23:39:34-04:00",
-            "objectID": 847
+            "objectID": 847,
+            "provider": "Amtrak"
         }
         ]
 }"#,


### PR DESCRIPTION
The Via rail network was added to Amtrak's API. Therefore the schema changed slightly. The object_id is only provided when the new provider tag is marked "Amtrak".